### PR TITLE
feat: improve the readability of hover tips

### DIFF
--- a/src/ui/planner/expeds-detail/exped-detail.js
+++ b/src/ui/planner/expeds-detail/exped-detail.js
@@ -28,6 +28,7 @@ class ExpedDetailImpl extends Component {
     return (
       <div style={{
         marginBottom: 6,
+        color: '#ffffff',
       }}>
         <div style={{display: 'flex', marginLeft: '2em'}}>
           <div
@@ -49,6 +50,7 @@ class ExpedDetailImpl extends Component {
             width: '30em',
             marginBottom: 0,
             marginTop: 5,
+            color: '#ffffff',
           }}
           condensed bordered>
           <tbody>


### PR DESCRIPTION
Change the text color of tooltips
before：
<img width="441" alt="image" src="https://github.com/user-attachments/assets/42496dbf-f33a-44b4-a0aa-2a5b7203e8a5">

after：
<img width="950" alt="image" src="https://github.com/user-attachments/assets/bb0a56f9-251f-48b1-8c52-63a5fd17cad3">

